### PR TITLE
OP-4430: Add S3 artifact bucket ownership controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Creates a codebuild project and S3 artifact bucket to be used with codepipeline.
 
 ```hcl
 module "codebuild_project" {
-  source = "github.com/globeandmail/aws-codebuild-project?ref=2.1"
+  source = "github.com/globeandmail/aws-codebuild-project?ref=2.2"
 
   name                                         = var.name
   deploy_type                                  = var.deploy_type

--- a/main.tf
+++ b/main.tf
@@ -24,9 +24,18 @@ resource "aws_s3_bucket_public_access_block" "artifact" {
   restrict_public_buckets = true
 }
 
+resource "aws_s3_bucket_ownership_controls" "artifact" {
+  bucket = aws_s3_bucket.artifact.id
+
+  rule {
+    object_ownership = "ObjectWriter"
+  }
+}
+
 resource "aws_s3_bucket_acl" "artifact" {
   bucket = aws_s3_bucket.artifact.id
   acl    = "private"
+  depends_on = [aws_s3_bucket_ownership_controls.artifact]
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "artifact" {


### PR DESCRIPTION
#### PR description

What is it for?
The PR is to fix the error encountered while running Terraform apply command. Stack Overflow post:
https://stackoverflow.com/questions/76049290/error-accesscontrollistnotsupported-when-trying-to-create-a-bucket-acl-in-aws.

#### Testing instructions

- Verify TF apply command error is resolved.

#### JIRA ticket information

Story: [OP-4430](https://jira.theglobeandmail.com/browse/OP-4430)


[OP-4430]: https://mathereconomics.atlassian.net/browse/OP-4430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ